### PR TITLE
docs: add disclaimer about graphql testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,31 @@ Name | Type | Default | Description
 ---- | ---- | ------- | -----------
 `name` | `string` | `ditto-test` | Test name.
 `err` | `string` | `ditto-log` | Test errors when calling the endpoint.
-`result` | `[]Endpoint` | Fetch result. 
+`result` | `[]Endpoint` | Fetch result.
+
+### GraphQL Testing
+
+This tool can also be used to test GraphQL queries and mutation. However, you cannot test two different query and mutations and expecting the same result. For example:
+
+```
+{\n  a {\n    foo\n  }\n}
+```
+
+```
+{\n  b {\n    foo\n  }\n}
+```
+
+Although the above queries returns the exact same result, `ditto` will always mark the test as fail since the query name is different.
+
+To address those issues, you can use [GraphQL alias](https://graphql.org/learn/queries/#aliases). For example, the test above should be executed as:
+
+```
+{\n  data: a {\n    foo\n  }\n}
+```
+
+```
+{\n  data: b {\n    foo\n  }\n}
+```
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -106,11 +106,19 @@ Name | Type | Default | Description
 This tool can also be used to test GraphQL queries and mutation. However, you cannot test two different query and mutations and expecting the same result. For example:
 
 ```
-{\n  a {\n    foo\n  }\n}
+{
+    a {
+        foo
+    }
+}
 ```
 
 ```
-{\n  b {\n    foo\n  }\n}
+{
+    b {
+        foo
+    }    
+}
 ```
 
 Although the above queries returns the exact same result, `ditto` will always mark the test as fail since the query name is different.
@@ -118,11 +126,19 @@ Although the above queries returns the exact same result, `ditto` will always ma
 To address those issues, you can use [GraphQL alias](https://graphql.org/learn/queries/#aliases). For example, the test above should be executed as:
 
 ```
-{\n  data: a {\n    foo\n  }\n}
+{
+    data: a {
+        foo
+    }
+}
 ```
 
 ```
-{\n  data: b {\n    foo\n  }\n}
+{
+    data: b {
+        foo
+    }
+}
 ```
 
 ### License


### PR DESCRIPTION
## Overview

This pull request adds disclaimer about GraphQL API testing, which will always fail if the query names are different.

To address this issue, user can use GraphQL alias.