### PR TITLE
feat: write result as json

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,10 @@ Name | Type | Default | Description
 ---- | ---- | ------- | -----------
 `test_directory` | `string` | `ditto-test` | Test directory which stores all test definitions that are going to be executed by Ditto.
 `log_directory` | `string` | `ditto-log` | Test execution log directory which stores all test logs when one or more tests are failing.
-`strict` | `boolean` | `false` | Determine if Ditto should stop test execution when one or more test definitions are invalid.
-`workers` | `integer` | `<all_cores>` | Determine the maximum number of tests that should be executed in parallel.
-`status` | `boolean` | `false` | Determine if passing tests should also require the same HTTP response status.
+`strict` | `boolean` | `false` | Stops test execution when one or more test definitions are invalid.
+`workers` | `integer` | `<all_cores>` | Maximum number of tests that can be executed in parallel.
+`status` | `boolean` | `false` | Require the same HTTP response status for all tests.
+`parse` | `boolean` | `false` | Write HTTP responses as JSON instead of raw string in test reports.
 
 ### Test Logs
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Name | Type | Default | Description
 `strict` | `boolean` | `false` | Stops test execution when one or more test definitions are invalid.
 `workers` | `integer` | `<all_cores>` | Maximum number of tests that can be executed in parallel.
 `status` | `boolean` | `false` | Require the same HTTP response status for all tests.
-`parse` | `boolean` | `false` | Write HTTP responses as JSON instead of raw string in test reports.
+`parse` | `boolean` | `false` | Write HTTP responses as JSON instead of raw string in test reports. If the parsing fails, `ditto` will write it as a string instead.
 
 ### Test Logs
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Test logs is an object with the following properties.
 Name | Type | Default | Description
 ---- | ---- | ------- | -----------
 `name` | `string` | `ditto-test` | Test name.
-`err` | `string` | `ditto-log` | Test errors when calling the endpoint.
+`error` | `string` | `ditto-log` | Test errors when calling the endpoint.
 `result` | `[]Endpoint` | Fetch result. 
 
 ### License

--- a/cmd/ditto/main.go
+++ b/cmd/ditto/main.go
@@ -75,7 +75,7 @@ func main() {
 	var fails []*entity.RunnerResult
 
 	for result := range channel {
-		fail := result.Error != nil || utils.HasDiff(result.Result, config)
+		fail := result.Error != nil || utils.HasDiff(result.Responses, config)
 
 		formatted := utils.FormatResult(result, !fail)
 		fmt.Println(formatted)

--- a/ditto.config.json
+++ b/ditto.config.json
@@ -1,5 +1,6 @@
 {
     "test_directory": "custom-test-folder",
     "log_directory": "custom-test-logs-folder",
-    "worker": 4
+    "worker": 4,
+    "parse": true
 }

--- a/internal/entity/config.go
+++ b/internal/entity/config.go
@@ -16,6 +16,7 @@ type Configuration struct {
 	Strict        bool   `json:"strict"`
 	Worker        int    `json:"worker" validate:"gte=1"`
 	Status        bool   `json:"status"`
+	Parse         bool   `json:"parse"`
 }
 
 // ReadConfiguration searches and parses ditto configuration file in the current working directory

--- a/internal/entity/config_test.go
+++ b/internal/entity/config_test.go
@@ -25,6 +25,7 @@ func TestReadConfiguration(t *testing.T) {
 				Strict:        false,
 				Worker:        0,
 				Status:        false,
+				Parse:         false,
 			},
 		},
 		{
@@ -37,6 +38,7 @@ func TestReadConfiguration(t *testing.T) {
 				Strict:        false,
 				Worker:        0,
 				Status:        false,
+				Parse:         false,
 			},
 		},
 		{
@@ -49,18 +51,20 @@ func TestReadConfiguration(t *testing.T) {
 				Strict:        false,
 				Worker:        0,
 				Status:        false,
+				Parse:         false,
 			},
 		},
 		{
 			name:     "should merge config",
 			path:     "ditto.config.json",
-			contents: []byte(`{ "test_directory": "bar", "log_directory": "baz", "strict": true, "worker": 2 }`),
+			contents: []byte(`{ "test_directory": "bar", "log_directory": "baz", "strict": true, "worker": 2, "parse": true }`),
 			want: &Configuration{
 				TestDirectory: "bar",
 				LogDirectory:  "baz",
 				Strict:        true,
 				Worker:        2,
 				Status:        false,
+				Parse:         true,
 			},
 		},
 	}

--- a/internal/entity/fetcher.go
+++ b/internal/entity/fetcher.go
@@ -3,6 +3,6 @@ package entity
 // FetchResult represents fetching result when testing endpoints
 type FetchResult struct {
 	Endpoint
-	Status   int    `json:"status"`
-	Response string `json:"response"`
+	Status   int         `json:"status"`
+	Response interface{} `json:"response"`
 }

--- a/internal/entity/runner.go
+++ b/internal/entity/runner.go
@@ -2,7 +2,7 @@ package entity
 
 // RunnerResult wraps a test runner result
 type RunnerResult struct {
-	Name   string
-	Error  error
-	Result []*FetchResult
+	Name      string
+	Error     error
+	Responses []*FetchResult
 }

--- a/internal/service/defs_test.go
+++ b/internal/service/defs_test.go
@@ -1,6 +1,8 @@
 package service
 
-import "testing"
+import (
+	"testing"
+)
 
 // TODO: Write this
 func TestGetDefs(t *testing.T) {

--- a/internal/service/logger.go
+++ b/internal/service/logger.go
@@ -17,7 +17,11 @@ type runnerResultLog struct {
 }
 
 // WriteTestLog writes test result in case of test fails
-func WriteTestLog(result *entity.RunnerResult, fsys fs.FS, config *entity.Configuration) error {
+func WriteTestLog(
+	result *entity.RunnerResult,
+	fsys fs.FS,
+	config *entity.Configuration,
+) error {
 	name := fmt.Sprintf("%s.json", result.Name)
 	file := fmt.Sprintf("%s/%s", config.LogDirectory, name)
 
@@ -27,10 +31,21 @@ func WriteTestLog(result *entity.RunnerResult, fsys fs.FS, config *entity.Config
 		errMsg = result.Error.Error()
 	}
 
+	if config.Parse {
+		for idx := range result.Responses {
+			var temp interface{}
+
+			err := json.Unmarshal([]byte(result.Responses[idx].Response.(string)), &temp)
+			if err == nil {
+				result.Responses[idx].Response = temp
+			}
+		}
+	}
+
 	runnerLog := runnerResultLog{
 		Name:   result.Name,
 		Err:    errMsg,
-		Result: result.Result,
+		Result: result.Responses,
 	}
 
 	contents, _ := json.MarshalIndent(runnerLog, "", "\t")

--- a/internal/service/runner.go
+++ b/internal/service/runner.go
@@ -53,8 +53,8 @@ func (r *TestRunner) RunTest(
 	}
 
 	ch <- &entity.RunnerResult{
-		Name:   r.data.Name,
-		Result: result,
+		Name:      r.data.Name,
+		Responses: result,
 	}
 }
 

--- a/internal/utils/formatter_test.go
+++ b/internal/utils/formatter_test.go
@@ -18,9 +18,9 @@ func TestFormatResult(t *testing.T) {
 		{
 			name: "should format error test",
 			args: &entity.RunnerResult{
-				Name:   "TestThisOne",
-				Error:  errors.New("foo bar"),
-				Result: []*entity.FetchResult{},
+				Name:      "TestThisOne",
+				Error:     errors.New("foo bar"),
+				Responses: []*entity.FetchResult{},
 			},
 			status: false,
 			want:   "TestThisOne: ❌ FAIL. Please check the generated test log.",
@@ -28,8 +28,8 @@ func TestFormatResult(t *testing.T) {
 		{
 			name: "should format passed test",
 			args: &entity.RunnerResult{
-				Name:   "TestThisOne",
-				Result: []*entity.FetchResult{},
+				Name:      "TestThisOne",
+				Responses: []*entity.FetchResult{},
 			},
 			status: true,
 			want:   "TestThisOne: ✅ PASS",
@@ -37,8 +37,8 @@ func TestFormatResult(t *testing.T) {
 		{
 			name: "should format failed test",
 			args: &entity.RunnerResult{
-				Name:   "TestThisOne",
-				Result: []*entity.FetchResult{},
+				Name:      "TestThisOne",
+				Responses: []*entity.FetchResult{},
 			},
 			status: false,
 			want:   "TestThisOne: ❌ FAIL. Please check the generated test log.",

--- a/internal/utils/fs_test.go
+++ b/internal/utils/fs_test.go
@@ -1,0 +1,46 @@
+package utils
+
+import (
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsFileExists(t *testing.T) {
+	tests := []struct {
+		name string
+		args string
+		mock fstest.MapFS
+		want bool
+	}{
+		{
+			name: "file exist",
+			args: "foo.txt",
+			mock: fstest.MapFS{
+				"foo.txt": {
+					Data: []byte("hello"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "file not exist",
+			args: "foo.txt",
+			mock: fstest.MapFS{
+				"bar.txt": {
+					Data: []byte("hello"),
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsFileExist(tc.mock, tc.args)
+
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Overview

Closes #3 

This pull request adds `parse` option to the runner that allows the logger to write the response result as pure JSON. Do note that if the response is not parseable as JSON, it will be written as a string instead.